### PR TITLE
refactor: remove trailing slashes from API endpoint paths

### DIFF
--- a/src/components/clerk/ClerkUploadedFiles.vue
+++ b/src/components/clerk/ClerkUploadedFiles.vue
@@ -278,7 +278,7 @@ async function ensureBlobUrl(type, { force = false } = {}) {
     state.loading[type] = true;
     state.error[type] = false;
 
-    const res = await ContentApiService.get('/download-file/', {
+    const res = await ContentApiService.get('/download-file', {
       params: { file_url: url },
       responseType: 'arraybuffer',
       validateStatus: (s) => s === 200,
@@ -410,7 +410,7 @@ async function fetchDocuments(studentUsername) {
   try {
     resetCache();
 
-    const res = await ContentApiService.get('/clerk/documents-by-username/', {
+    const res = await ContentApiService.get('/clerk/documents-by-username', {
       params: { student_username: studentUsername },
     });
 

--- a/src/views/RoleDashboard.vue
+++ b/src/views/RoleDashboard.vue
@@ -57,7 +57,7 @@ const fetchPetitions = async () => {
   isLoading.value = true;
   try {
     const response = await ContentApiService.get(
-      userRole.value === 0 ? '/students/petitions/' : '/supervisor/petitions/'
+      userRole.value === 0 ? '/students/petitions' : '/supervisor/petitions'
     );
     petitions.value = response.data;
   } catch (err) {


### PR DESCRIPTION
Backend updated routes that were ending with trailing slashes so this PR updates the routes that were ending with trailing slashes.
closes #59 