### PR TITLE
Feature/centralize conversion logic in petition model

### DIFF
--- a/src/components/tables/base/PetitionTable.vue
+++ b/src/components/tables/base/PetitionTable.vue
@@ -27,8 +27,6 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { isStudent } from '@/utils/roleUtils';
-import { parseISO } from 'date-fns';
-import { localizedFormat } from '@/utils/date';
 import PetitionStatusIcon from '@/components/ui/PetitionStatusIcon.vue';
 import BaseDataDisplayTable from '@/components/tables/base/DataDisplayTable.vue';
 
@@ -45,16 +43,6 @@ const { t } = useI18n();
 const formatValue = (value, key) => {
   if (value === null || value === undefined || value === '') {
     return '-';
-  }
-  if (
-    typeof value === 'string' &&
-    (key.includes('Date') || key.includes('Start') || key.includes('End'))
-  ) {
-    try {
-      return localizedFormat(parseISO(value), 'dd.MM.yyyy');
-    } catch {
-      return value;
-    }
   }
   if (typeof value === 'boolean') {
     return value ? t('yes') : t('no');

--- a/src/components/tables/base/PetitionsOverviewTable.vue
+++ b/src/components/tables/base/PetitionsOverviewTable.vue
@@ -46,7 +46,6 @@
 
 <script setup>
 import { computed } from 'vue';
-import { format, parseISO } from 'date-fns';
 import PetitionStatusIcon from '@/components/ui/PetitionStatusIcon.vue';
 import StatusIndicator from '@/components/ui/StatusIndicator.vue';
 
@@ -70,24 +69,7 @@ const emit = defineEmits(['row-click']);
 const formattedItems = computed(() => {
   return props.items.map((item) => {
     const formattedItem = { ...item };
-    // Format dates in items to dd.mm.yyyy
-    const dateFields = [
-      'start_date',
-      'end_date',
-      'time_exce_start',
-      'time_exce_end',
-      'duration_exce_start',
-      'duration_exce_end',
-    ];
 
-    dateFields.forEach((field) => {
-      if (formattedItem[field] && typeof formattedItem[field] === 'string') {
-        formattedItem[field] = format(
-          parseISO(formattedItem[field]),
-          'dd.MM.yyyy'
-        );
-      }
-    });
     formattedItem['student_mail'] =
       `${formattedItem['student_username']}@stud.uni-frankfurt.de`;
     return formattedItem;

--- a/src/models/Petition.js
+++ b/src/models/Petition.js
@@ -1,4 +1,5 @@
-import { localizedFormat, localizedParse } from '@/utils/date';
+import { localizedFormat } from '@/utils/date';
+import { parse, isValid } from 'date-fns';
 
 const DATE_KEYS = [
   'start_date',
@@ -48,23 +49,16 @@ class Petition {
 
   parseDate(value) {
     if (!value) return null;
+    if (value instanceof Date) return isValid(value) ? value : null;
 
-    const isValidDate = (d) => d instanceof Date && !Number.isNaN(d.getTime());
-
-    if (isValidDate(value)) return value;
-
-    if (typeof value !== 'string') return null;
-
-    const s = value.trim();
-    if (!s) return null;
-
-    const d1 = localizedParse(s, 'yyyy-MM-dd', new Date());
-    if (isValidDate(d1)) return d1;
-
-    const d2 = localizedParse(s, 'dd.MM.yyyy', new Date());
-    if (isValidDate(d2)) return d2;
-
-    return null;
+    const s = String(value).trim();
+    // Return the first valid date found from our supported formats
+    return (
+      [
+        parse(s, 'yyyy-MM-dd', new Date()),
+        parse(s, 'dd.MM.yyyy', new Date()),
+      ].find(isValid) || null
+    );
   }
 
   static fromBackendResponse(data) {

--- a/src/models/Petition.js
+++ b/src/models/Petition.js
@@ -1,4 +1,4 @@
-import { parse, format, isValid } from 'date-fns';
+import { localizedFormat, localizedParse } from '@/utils/date';
 
 const DATE_KEYS = [
   'start_date',
@@ -17,7 +17,7 @@ class Petition {
     this.student_username = data.student_username || '';
     this.org_unit = data.org_unit || '';
     this.eos_number = data.eos_number || '';
-    this.minutes = data.minutes || 0;
+    this.minutes = data.minutes ? Number(data.minutes) / 60 : 0;
     this.ba_degree = data.ba_degree ?? false;
     this.status = data.status || '';
     this.time_exce_student = data.time_exce_student ?? false;
@@ -38,26 +38,31 @@ class Petition {
 
     DATE_KEYS.forEach((key) => {
       if (data[key]) {
-        this[key] = this.parseDate(data[key]);
+        const d = this.parseDate(data[key]);
+        this[key] = d ? localizedFormat(d, 'dd.MM.yyyy') : null;
       } else {
         this[key] = null;
       }
     });
   }
 
-  parseDate(dateValue) {
-    if (!dateValue) return null;
+  parseDate(value) {
+    if (!value) return null;
 
-    if (dateValue instanceof Date && isValid(dateValue)) {
-      return dateValue;
-    }
-    if (typeof dateValue === 'string') {
-      const dateObj = new Date(dateValue);
-      if (isValid(dateObj)) return dateObj;
+    const isValidDate = (d) => d instanceof Date && !Number.isNaN(d.getTime());
 
-      const parsedDate = parse(dateValue, 'dd.MM.yyyy', new Date());
-      if (isValid(parsedDate)) return parsedDate;
-    }
+    if (isValidDate(value)) return value;
+
+    if (typeof value !== 'string') return null;
+
+    const s = value.trim();
+    if (!s) return null;
+
+    const d1 = localizedParse(s, 'yyyy-MM-dd', new Date());
+    if (isValidDate(d1)) return d1;
+
+    const d2 = localizedParse(s, 'dd.MM.yyyy', new Date());
+    if (isValidDate(d2)) return d2;
 
     return null;
   }
@@ -69,12 +74,16 @@ class Petition {
   toBackendFormat() {
     const formattedData = { ...this };
 
+    // Frontend uses hours in 'minutes' field; convert to total minutes for backend
+    if (formattedData.minutes) {
+      formattedData.minutes = Math.round(
+        parseFloat(formattedData.minutes) * 60
+      );
+    }
+
     DATE_KEYS.forEach((key) => {
-      if (formattedData[key] && isValid(formattedData[key])) {
-        formattedData[key] = format(formattedData[key], 'yyyy-MM-dd');
-      } else {
-        formattedData[key] = null;
-      }
+      const d = this.parseDate(formattedData[key]);
+      formattedData[key] = d ? localizedFormat(d, 'yyyy-MM-dd') : null;
     });
 
     // Exclude 'status' and any empty or null fields

--- a/src/views/ApproverView.vue
+++ b/src/views/ApproverView.vue
@@ -114,11 +114,11 @@
 </template>
 
 <script setup>
-import { PETITION_STATUS } from '@/utils/statusUtils';
 import { ref, computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
+import Petition from '@/models/Petition';
 import ContentApiService from '@/services/contentApiService';
 import PetitionTable from '@/components/tables/base/PetitionTable.vue';
 import PetitionRevisionDialog from '@/components/dialogs/PetitionRevisionDialog.vue';
@@ -158,7 +158,7 @@ const fetchPetition = async () => {
     const response = await ContentApiService.get(
       `/approver/petitions/${petitionId}/${signature}/${budgetPositionId}`
     );
-    petition.value = response.data;
+    petition.value = new Petition(response.data);
   } catch (err) {
     console.error(err);
     const errorMessage = err.response?.data?.detail

--- a/src/views/ClerkView.vue
+++ b/src/views/ClerkView.vue
@@ -31,10 +31,11 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
+import { log } from '@/utils/log';
+import Petition from '@/models/Petition';
 import ContentApiService from '@/services/contentApiService';
 import ClerkDataDisplay from '@/components/clerk/ClerkDataDisplay.vue';
 import ClerkPetitionTable from '@/components/tables/ClerkPetitionTable.vue';
-import { log } from '@/utils/log';
 
 const store = useStore();
 const { t } = useI18n();
@@ -68,7 +69,7 @@ const connectWebSocket = () => {
       message.type === 'new_petition' ||
       message.type === 'updated_petitions'
     ) {
-      const incomingPetitions = message.data;
+      const incomingPetitions = message.data.map((item) => new Petition(item));
       petitions.value = incomingPetitions;
     }
   };
@@ -112,7 +113,7 @@ const handleApproval = async (petitionId) => {
 const handleRefresh = async () => {
   try {
     const response = await ContentApiService.get('/clerk/petitions');
-    petitions.value = response.data;
+    petitions.value = response.data.map((item) => new Petition(item));
   } catch (error) {
     if (error.response?.status === 404) {
       petitions.value = [];

--- a/src/views/ClerkView.vue
+++ b/src/views/ClerkView.vue
@@ -49,7 +49,7 @@ const user = computed(() => store.getters['auth/user']);
 const connectWebSocket = () => {
   const clerkId = user.value.id;
   const baseUri = import.meta.env.VITE_WEBSOCKET_URI;
-  
+
   const isLocal = baseUri.includes('localhost');
   const protocol = isLocal ? 'ws' : 'wss';
 

--- a/src/views/RoleDashboard.vue
+++ b/src/views/RoleDashboard.vue
@@ -30,6 +30,7 @@ import { ref, onMounted, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { Roles, currentRole } from '@/utils/roleUtils';
+import Petition from '@/models/Petition';
 import ContentApiService from '@/services/contentApiService';
 import EditCard from '@/components/dashboard/EditCard.vue';
 import OverviewCard from '@/components/dashboard/OverviewCard.vue';
@@ -53,7 +54,7 @@ const fetchPetitions = async () => {
         ? '/supervisor/petitions'
         : '/students/petitions'
     );
-    petitions.value = response.data;
+    petitions.value = response.data.map((item) => new Petition(item));
   } catch (err) {
     if (err.response?.status === 404) {
       petitions.value = [];


### PR DESCRIPTION
Centralize all date and time conversion logic exclusively within the Petition model to ensure consistent data handling between backend and frontend. This includes: minutes (being multiplied by 60 for backend and divided by 60 for frontend )and all DATE_KEYS date formatting to dd.MM.yyyy
closes #76 